### PR TITLE
Fix config reload and lifecycle edge cases in Stark

### DIFF
--- a/Stark/Managers/ConfigManager.swift
+++ b/Stark/Managers/ConfigManager.swift
@@ -52,31 +52,39 @@ final class ConfigManager {
   }
 
   private func load() -> Result<Void, Error> {
-    Keymap.reset()
-    Event.reset()
+    let nextContext: JSContext
 
-    ShortcutManager.stop()
-    ShortcutManager.reset()
-
-    switch setupAPI() {
-    case .success:
-      break
+    switch createContext() {
+    case .success(let context):
+      nextContext = context
     case .failure(let error):
       return .failure(error)
     }
 
-    switch executeConfig() {
+    Keymap.beginRecording()
+    Event.beginRecording()
+
+    switch executeConfig(in: nextContext) {
     case .success:
+      ShortcutManager.stop()
+      ShortcutManager.reset()
+
+      context = nextContext
+
+      Event.commitRecording()
+      Keymap.commitRecording()
       ShortcutManager.start()
+
       return .success(())
     case .failure(let error):
+      Keymap.discardRecording()
+      Event.discardRecording()
       return .failure(error)
     }
   }
 
-  private func setupAPI() -> Result<Void, JSExceptionError> {
-    context = nil
-    context = JSContext(virtualMachine: JSVirtualMachine())
+  private func createContext() -> Result<JSContext, JSExceptionError> {
+    let context = JSContext(virtualMachine: JSVirtualMachine())
 
     guard let context else {
       return .failure(.exception("Could not create javascript context"))
@@ -97,16 +105,12 @@ final class ConfigManager {
     context.setObject(Application.self, forKeyedSubscript: "Application" as NSString)
     context.setObject(Window.self, forKeyedSubscript: "Window" as NSString)
 
-    return .success(())
+    return .success(context)
   }
 
-  private func executeConfig() -> Result<Void, Error> {
+  private func executeConfig(in context: JSContext) -> Result<Void, Error> {
     if !FileManager.default.fileExists(atPath: path) {
       return .failure(FileError.notFound(path))
-    }
-
-    guard let context else {
-      return .failure(StateError.invalidState("javascript context is not defined"))
     }
 
     guard let scriptContents = try? String(contentsOfFile: path, encoding: .utf8) else {

--- a/Stark/Managers/ConfigManager.swift
+++ b/Stark/Managers/ConfigManager.swift
@@ -22,6 +22,7 @@ final class ConfigManager {
 
   private var path: String = resolvePrimaryPath()
   private var fileSystemSource: DispatchSourceFileSystemObject?
+  private let fileMonitorQueue = DispatchQueue(label: "dev.tombell.stark.config")
 
   private var context: JSContext?
 
@@ -136,21 +137,25 @@ final class ConfigManager {
 
     let source = DispatchSource.makeFileSystemObjectSource(
       fileDescriptor: fd,
-      eventMask: .write,
-      queue: DispatchQueue(label: "dev.tombell.stark.config")
+      eventMask: [.write, .delete, .rename],
+      queue: fileMonitorQueue
     )
 
     fileSystemSource = source
 
-    source.setEventHandler { [weak self] in
-      log("config file changed, reloading...", level: .info)
+    source.setEventHandler { [weak self, weak source] in
+      guard let self, let source else { return }
 
-      guard let self else { return }
+      let events = source.data
+      let needsMonitorRestart = events.contains(.delete) || events.contains(.rename)
+      let needsReload = needsMonitorRestart || events.contains(.write)
 
-      switch self.load() {
-      case .success: break
-      case .failure(let error):
-        log("could not reload config file: \(error)", level: .error)
+      if needsMonitorRestart {
+        self.restartFileMonitor()
+      }
+
+      if needsReload {
+        self.reloadConfig()
       }
     }
 
@@ -161,5 +166,26 @@ final class ConfigManager {
     source.resume()
 
     return .success(())
+  }
+
+  private func reloadConfig() {
+    log("config file changed, reloading...", level: .info)
+
+    switch load() {
+    case .success: break
+    case .failure(let error):
+      log("could not reload config file: \(error)", level: .error)
+    }
+  }
+
+  private func restartFileMonitor() {
+    fileSystemSource?.cancel()
+    fileSystemSource = nil
+
+    switch setupFileMonitor() {
+    case .success: break
+    case .failure(let error):
+      log("could not restart config monitor: \(error)", level: .error)
+    }
   }
 }

--- a/Stark/Models/Application.swift
+++ b/Stark/Models/Application.swift
@@ -223,10 +223,7 @@ class Application: NSObject, ApplicationJSExport {
   }
 
   func unobserve() {
-    guard
-      !observing,
-      let observer = observer
-    else { return }
+    guard let observer = observer else { return }
 
     for (idx, notification) in applicationNotifications.enumerated() {
       let notif = ApplicationNotifications(rawValue: 1 << idx)
@@ -237,10 +234,12 @@ class Application: NSObject, ApplicationJSExport {
       observedNotifications.remove(notif)
     }
 
-    CFRunLoopSourceInvalidate(AXObserverGetRunLoopSource(observer))
+    if observing {
+      CFRunLoopSourceInvalidate(AXObserverGetRunLoopSource(observer))
+      observing = false
+    }
 
     self.observer = nil
-    observing = false
   }
 
   func windowIdentifiers() -> [CGWindowID] {

--- a/Stark/Models/Event.swift
+++ b/Stark/Models/Event.swift
@@ -30,7 +30,42 @@ import JavaScriptCore
 
 class Event: NSObject, EventJSExport {
   private static var callbacks: [EventType: [Event]] = [:]
+  private static var recordingCallbacks: [EventType: [Event]]?
   private static let queue = DispatchQueue(label: "dev.tombell.stark.events")
+
+  static func beginRecording() {
+    queue.sync {
+      recordingCallbacks = [:]
+    }
+  }
+
+  static func commitRecording() {
+    let activeListeners: [Event] = queue.sync {
+      guard let recordingCallbacks else { return [] }
+
+      let activeListeners = callbacks.values.flatMap { $0 }
+      callbacks = recordingCallbacks
+      self.recordingCallbacks = nil
+
+      return activeListeners
+    }
+
+    for listener in activeListeners {
+      removeManagedReference(for: listener)
+    }
+  }
+
+  static func discardRecording() {
+    let listeners: [Event] = queue.sync {
+      let listeners = recordingCallbacks?.values.flatMap { $0 } ?? []
+      recordingCallbacks = nil
+      return listeners
+    }
+
+    for listener in listeners {
+      removeManagedReference(for: listener)
+    }
+  }
 
   static func callbacks(for event: EventType) -> [Event] {
     queue.sync { callbacks[event] ?? [] }
@@ -43,6 +78,17 @@ class Event: NSObject, EventJSExport {
     }
 
     let listener = Event(event: event, callback: callback)
+
+    if recordingCallbacks != nil {
+      queue.sync {
+        var list = recordingCallbacks?[eventType] ?? []
+        list.append(listener)
+        recordingCallbacks?[eventType] = list
+      }
+
+      callback.context.virtualMachine.addManagedReference(listener, withOwner: self)
+      return listener
+    }
 
     queue.sync {
       var list = callbacks[eventType] ?? []
@@ -58,20 +104,44 @@ class Event: NSObject, EventJSExport {
   static func off(_ event: String) {
     guard let eventType = EventType(rawValue: event) else { return }
 
+    if recordingCallbacks != nil {
+      let removed: [Event] = queue.sync {
+        let list = recordingCallbacks?.removeValue(forKey: eventType) ?? []
+        return list
+      }
+
+      for listener in removed {
+        removeManagedReference(for: listener)
+      }
+
+      return
+    }
+
     let removed: [Event] = queue.sync {
       let list = callbacks.removeValue(forKey: eventType) ?? []
       return list
     }
 
     for listener in removed {
-      listener.callback?.value?.context.virtualMachine.removeManagedReference(
-        listener,
-        withOwner: self
-      )
+      removeManagedReference(for: listener)
     }
   }
 
   static func reset() {
+    if recordingCallbacks != nil {
+      let all: [Event] = queue.sync {
+        let list = recordingCallbacks?.values.flatMap { $0 } ?? []
+        recordingCallbacks?.removeAll()
+        return list
+      }
+
+      for listener in all {
+        removeManagedReference(for: listener)
+      }
+
+      return
+    }
+
     let all: [Event] = queue.sync {
       let list = callbacks.values.flatMap { $0 }
       callbacks.removeAll()
@@ -79,11 +149,14 @@ class Event: NSObject, EventJSExport {
     }
 
     for listener in all {
-      listener.callback?.value?.context.virtualMachine.removeManagedReference(
-        listener,
-        withOwner: self
-      )
+      removeManagedReference(for: listener)
     }
+  }
+
+  private static func removeManagedReference(for listener: Event) {
+    guard let callback = listener.callback?.value else { return }
+
+    callback.context.virtualMachine.removeManagedReference(listener, withOwner: self)
   }
 
   var id: String

--- a/Stark/Models/Keymap.swift
+++ b/Stark/Models/Keymap.swift
@@ -33,6 +33,10 @@ class Keymap: NSObject, KeymapJSExport {
   private static var keymaps = [String: Keymap]()
   private static var recordingKeymaps: [String: Keymap]?
 
+  private static func identifier(for key: String, modifiers: [String]) -> String {
+    String(format: "%@[%@]", key, modifiers.joined(separator: "|"))
+  }
+
   static func beginRecording() {
     recordingKeymaps = [:]
   }
@@ -63,6 +67,14 @@ class Keymap: NSObject, KeymapJSExport {
   }
 
   static func on(_ key: String, _ modifiers: [String], _ callback: JSValue) -> Keymap {
+    if recordingKeymaps == nil {
+      let id = identifier(for: key, modifiers: modifiers)
+
+      if keymaps[id] != nil {
+        off(id)
+      }
+    }
+
     let keymap = Keymap(
       key: key,
       modifiers: modifiers,
@@ -126,7 +138,7 @@ class Keymap: NSObject, KeymapJSExport {
   }
 
   var id: String {
-    String(format: "%@[%@]", key, modifiers.joined(separator: "|"))
+    Self.identifier(for: key, modifiers: modifiers)
   }
 
   var key: String

--- a/Stark/Models/Keymap.swift
+++ b/Stark/Models/Keymap.swift
@@ -31,27 +31,94 @@ import JavaScriptCore
 
 class Keymap: NSObject, KeymapJSExport {
   private static var keymaps = [String: Keymap]()
+  private static var recordingKeymaps: [String: Keymap]?
+
+  static func beginRecording() {
+    recordingKeymaps = [:]
+  }
+
+  static func commitRecording() {
+    guard let recordingKeymaps else { return }
+
+    for keymap in keymaps.values {
+      removeManagedReference(for: keymap)
+    }
+
+    keymaps = recordingKeymaps
+    Self.recordingKeymaps = nil
+
+    for keymap in keymaps.values {
+      keymap.activate()
+    }
+  }
+
+  static func discardRecording() {
+    guard let recordingKeymaps else { return }
+
+    for keymap in recordingKeymaps.values {
+      removeManagedReference(for: keymap)
+    }
+
+    Self.recordingKeymaps = nil
+  }
 
   static func on(_ key: String, _ modifiers: [String], _ callback: JSValue) -> Keymap {
-    let keymap = Keymap(key: key, modifiers: modifiers, callback: callback)
-    keymaps[keymap.id] = keymap
+    let keymap = Keymap(
+      key: key,
+      modifiers: modifiers,
+      callback: callback,
+      activateShortcut: recordingKeymaps == nil
+    )
 
     callback.context.virtualMachine.addManagedReference(keymap, withOwner: self)
+
+    if var recordingKeymaps {
+      if let previous = recordingKeymaps[keymap.id] {
+        removeManagedReference(for: previous)
+      }
+
+      recordingKeymaps[keymap.id] = keymap
+      Self.recordingKeymaps = recordingKeymaps
+      return keymap
+    }
+
+    keymaps[keymap.id] = keymap
 
     return keymap
   }
 
   static func off(_ id: String) {
+    if var recordingKeymaps {
+      guard let keymap = recordingKeymaps.removeValue(forKey: id) else { return }
+
+      removeManagedReference(for: keymap)
+      Self.recordingKeymaps = recordingKeymaps
+      return
+    }
+
     guard let keymap = keymaps.removeValue(forKey: id) else { return }
 
-    keymap.callback?.value.context.virtualMachine.removeManagedReference(keymap, withOwner: self)
+    removeManagedReference(for: keymap)
     ShortcutManager.unregister(shortcut: keymap.shortcut)
   }
 
   static func reset() {
+    if let recordingKeymaps {
+      for id in recordingKeymaps.keys {
+        off(id)
+      }
+      return
+    }
+
     for id in keymaps.keys {
       off(id)
     }
+  }
+
+  private static func removeManagedReference(for keymap: Keymap) {
+    guard let callback = keymap.callback?.value else { return }
+
+    callback.context.virtualMachine.removeManagedReference(keymap, withOwner: self)
   }
 
   override var description: String {
@@ -68,7 +135,7 @@ class Keymap: NSObject, KeymapJSExport {
   private var shortcut: Shortcut
   private var callback: JSManagedValue?
 
-  init(key: String, modifiers: [String], callback: JSValue) {
+  init(key: String, modifiers: [String], callback: JSValue, activateShortcut: Bool) {
     self.key = key
     self.modifiers = modifiers
 
@@ -80,11 +147,18 @@ class Keymap: NSObject, KeymapJSExport {
 
     self.callback = JSManagedValue(value: callback, andOwner: self)
     shortcut.handler = call
-    ShortcutManager.register(shortcut: shortcut)
+
+    if activateShortcut {
+      activate()
+    }
   }
 
   deinit {
     log("keymap deinit \(self)")
+  }
+
+  func activate() {
+    ShortcutManager.register(shortcut: shortcut)
   }
 
   private func call() {

--- a/Stark/Models/Space.swift
+++ b/Stark/Models/Space.swift
@@ -69,7 +69,11 @@ class Space: NSObject, SpaceJSExport {
   }
 
   static func at(_ index: Int) -> Space? {
-    all()[index]
+    let spaces = all()
+
+    guard spaces.indices.contains(index) else { return nil }
+
+    return spaces[index]
   }
 
   static func active() -> Space {

--- a/Stark/Models/Workspace.swift
+++ b/Stark/Models/Workspace.swift
@@ -84,7 +84,7 @@ class Workspace: NSObject {
       let context: UnsafeMutableRawPointer? = Unmanaged.passUnretained(process).toOpaque()
 
       log("removing observer for finished launching \(process)")
-      finishedLaunchingObserved.removeAll(where: { $0 == process.psn.lowLongOfPSN })jj
+      finishedLaunchingObserved.removeAll(where: { $0 == process.psn.lowLongOfPSN })
       application.removeObserver(
         Workspace.shared,
         forKeyPath: "finishedLaunching",

--- a/Stark/Models/Workspace.swift
+++ b/Stark/Models/Workspace.swift
@@ -84,7 +84,7 @@ class Workspace: NSObject {
       let context: UnsafeMutableRawPointer? = Unmanaged.passUnretained(process).toOpaque()
 
       log("removing observer for finished launching \(process)")
-      finishedLaunchingObserved.removeAll(where: { $0 == process.psn.lowLongOfPSN })
+      finishedLaunchingObserved.removeAll(where: { $0 == process.psn.lowLongOfPSN })jj
       application.removeObserver(
         Workspace.shared,
         forKeyPath: "finishedLaunching",


### PR DESCRIPTION
## Summary
- make `Space.at` return `nil` instead of crashing on invalid indices
- fix `Application.unobserve()` so AX observers and run loop sources are actually torn down
- make config reloads transactional so a broken config does not discard the last working keymaps and event handlers
- recreate the config file watcher after atomic saves and handle rename/delete events
- replace existing keymaps before re-registering hotkeys to avoid leaked handlers and duplicate registrations

## Testing
- `xcodebuild -project Stark.xcodeproj -scheme Stark -derivedDataPath /tmp/stark-derived build`